### PR TITLE
Check for existence of keys in `delete` routines

### DIFF
--- a/bitmapist4/core.py
+++ b/bitmapist4/core.py
@@ -216,7 +216,7 @@ class Bitmapist(object):
         Delete all events from the database.
         """
         keys = self.connection.keys('{}*'.format(self.key_prefix))
-        if len(keys) > 0:
+        if keys:
             self.connection.delete(*keys)
 
     def delete_temporary_bitop_keys(self):
@@ -224,7 +224,7 @@ class Bitmapist(object):
         Delete all temporary keys that are used when using bit operations.
         """
         keys = self.connection.keys('{}bitop_*'.format(self.key_prefix))
-        if len(keys) > 0:
+        if keys:
             self.connection.delete(*keys)
 
     def prefix_key(self, event_name, date):


### PR DESCRIPTION
Hi all 👋

When calling `delete_all_events` and `delete_temporary_bitop_keys` with an empty `keys` object the following exception is thrown: 

`TypeError: object of type 'NoneType' has no len()`

This was also pointed out in the repo of the previous version here: https://github.com/Doist/bitmapist/issues/31

To prevent the error from being thrown I changed the `if len(keys) > 0` check to just `if keys`, as this both checks if it exists and if its length is greater than 0 (an empty list is falsy).

What do you think about this as a solution?  